### PR TITLE
Adding shared logger

### DIFF
--- a/forklet/__main__.py
+++ b/forklet/__main__.py
@@ -4,6 +4,7 @@ import logging
 
 import click
 
+from forklet.infrastructure.logger import logger
 from forklet.interfaces.cli import ForkletCLI
 from forklet.models import DownloadStrategy
 
@@ -21,7 +22,7 @@ def cli(ctx, verbose: bool, token: Optional[str]):
     ctx.obj['token'] = token
     
     if verbose:
-        logging.getLogger().setLevel(logging.DEBUG)
+        logger.setLevel(logging.DEBUG)
         click.echo("🔍 Verbose mode enabled")
 
 

--- a/forklet/core/orchestrator.py
+++ b/forklet/core/orchestrator.py
@@ -3,7 +3,6 @@ Orchestrator for managing the complete download process
 with concurrency and error handling.
 """
 
-import logging
 import concurrent.futures
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from pathlib import Path
@@ -18,8 +17,8 @@ from ..models import (
 from ..services import GitHubAPIService, DownloadService
 from .filter import FilterEngine, FilterResult
 
+from forklet.infrastructure.logger import logger
 
-logger = logging.getLogger(__name__)
 
 
 ####

--- a/forklet/infrastructure/error_handler.py
+++ b/forklet/infrastructure/error_handler.py
@@ -2,15 +2,14 @@
 Error handling utilities and decorators for robust operation.
 """
 
-import logging
 import functools
 from typing import Callable, Any, Optional
 
 import httpx
 from github import GithubException
 
+from forklet.infrastructure.logger import logger
 
-logger = logging.getLogger(__name__)
 
 
 

--- a/forklet/infrastructure/logger.py
+++ b/forklet/infrastructure/logger.py
@@ -1,0 +1,14 @@
+import logging
+import sys
+
+# Configure logging
+logging.basicConfig(
+    level=logging.INFO,
+    format='%(asctime)s - %(name)s - %(levelname)s - %(message)s',
+    handlers=[
+        logging.StreamHandler(sys.stdout),
+        logging.FileHandler('forklet.log')
+    ]
+)
+
+logger = logging.getLogger("Forklet")

--- a/forklet/infrastructure/retry_manager.py
+++ b/forklet/infrastructure/retry_manager.py
@@ -3,15 +3,14 @@ Retry management for network operations with exponential backoff.
 """
 
 import time
-import logging
 from typing import Callable, Optional, Type, Any
 from dataclasses import dataclass
 from requests.exceptions import (
     RequestException, Timeout, ConnectionError
 )
 
+from forklet.infrastructure.logger import logger
 
-logger = logging.getLogger(__name__)
 
 
 ####

--- a/forklet/interfaces/api.py
+++ b/forklet/interfaces/api.py
@@ -3,7 +3,6 @@
 Python API for Forklet GitHub Repository Downloader.
 """
 
-import logging
 from typing import Optional, List, Dict, Any, Callable
 from pathlib import Path
 from dataclasses import dataclass
@@ -11,13 +10,13 @@ from dataclasses import dataclass
 from forklet.core import DownloadOrchestrator
 from forklet.services import GitHubAPIService, DownloadService
 from forklet.infrastructure import RateLimiter, RetryManager
+from forklet.infrastructure.logger import logger
 from forklet.models import (
     DownloadRequest, DownloadResult, DownloadStrategy, FilterCriteria,
     RepositoryInfo, GitReference, ProgressInfo
 )
 
 
-logger = logging.getLogger(__name__)
 
 
 @dataclass

--- a/forklet/interfaces/cli.py
+++ b/forklet/interfaces/cli.py
@@ -15,23 +15,14 @@ from forklet.infrastructure import (
     RateLimiter, RetryManager, DownloadError, 
     RateLimitError, AuthenticationError, RepositoryNotFoundError
 )
+from forklet.infrastructure.logger import logger
 from forklet.models import (
     DownloadRequest, DownloadStrategy, FilterCriteria,
     DownloadResult
 )
 
 
-# Configure logging
-logging.basicConfig(
-    level=logging.INFO,
-    format='%(asctime)s - %(name)s - %(levelname)s - %(message)s',
-    handlers=[
-        logging.StreamHandler(sys.stdout),
-        logging.FileHandler('forklet.log')
-    ]
-)
 
-logger = logging.getLogger(__name__)
 
 
 class ForkletCLI:

--- a/forklet/services/download.py
+++ b/forklet/services/download.py
@@ -2,7 +2,6 @@
 Service for downloading files with progress tracking and error handling.
 """
 
-import logging
 from typing import Optional, Callable
 from pathlib import Path
 from dataclasses import dataclass
@@ -19,8 +18,8 @@ from ..infrastructure.error_handler import (
 from ..models import ProgressInfo
 from ..models.constants import USER_AGENT
 
+from forklet.infrastructure.logger import logger
 
-logger = logging.getLogger(__name__)
 
 
 ####

--- a/forklet/services/github_api.py
+++ b/forklet/services/github_api.py
@@ -2,7 +2,6 @@
 Service for interacting with GitHub API with rate limiting and error handling.
 """
 
-import logging
 from typing import List, Optional, Dict, Any
 
 # import requests
@@ -22,8 +21,8 @@ from ..models import (
 )
 from ..models.constants import USER_AGENT
 
+from forklet.infrastructure.logger import logger
 
-logger = logging.getLogger(__name__)
 
 
 ####


### PR DESCRIPTION
Added infrastructure/logger.py
Replaced all instances of `logger = logging.getLogger(__name__)` with `infrastructure.logger.logger`

I stumbled across #17 and it seemed straight forward so I took a few minutes to open a PR