### PR TITLE
Implemented filter engine testing for 6 scenarios.

### DIFF
--- a/tests/test_filter_engine.py
+++ b/tests/test_filter_engine.py
@@ -1,0 +1,101 @@
+from forklet.core.filter import FilterEngine
+from forklet.models import FilterCriteria, GitHubFile
+
+
+def make_file(path: str, size: int = 100, file_type: str = 'blob') -> GitHubFile:
+    """Helper function to build GithubFile instances for tests."""
+    return GitHubFile(path=path, type=file_type, size=size)
+
+
+def test_include_pattern_matches() -> None:
+    """Scenario: Path matching with include_patterns"""
+    criteria = FilterCriteria(include_patterns=['*.py'])
+    assert criteria.matches_path('main.py') is True
+    assert criteria.matches_path('README.md') is False
+    return None
+
+
+def test_exclude_pattern_blocks_path() -> None:
+    """Scenario: Path exclusion with exclude_patterns"""
+    criteria = FilterCriteria(exclude_patterns=['*.md'])
+    assert criteria.matches_path('script.py') is True
+    assert criteria.matches_path('docs/README.md') is False
+    return None
+
+
+def test_hidden_files_handling() -> None:
+    """Scenario: Handling of hidden files (with include_hidden=True/False)"""
+    hidden_path = '.github/workflows/ci.yml'
+    visible_criteria = FilterCriteria(include_hidden=False)
+    assert visible_criteria.matches_path(hidden_path) is False
+
+    hidden_criteria = FilterCriteria(include_hidden=True)
+    assert hidden_criteria.matches_path(hidden_path) is True
+    return None
+
+
+def test_file_extension_filters() -> None:
+    """Scenario: File extension filtering (file_extensions and excluded_extensions)"""
+    criteria = FilterCriteria(
+        file_extensions={'.py'}, excluded_extensions={'.log'})
+    assert criteria.matches_path('src/app.py') is True
+    assert criteria.matches_path('src/app.txt') is False
+    assert criteria.matches_path('logs/error.log') is False
+    return None
+
+
+def test_target_paths_enforcement() -> None:
+    """Scenario: target_paths enforcement"""
+    criteria = FilterCriteria(
+        target_paths=['docs/'], include_patterns=['*.md'])
+    assert criteria.matches_path('docs/guide.md') is True
+    assert criteria.matches_path('src/guide.md') is False
+
+    engine = FilterEngine(criteria)
+    target_file = make_file('docs/guide.txt')
+    off_target_file = make_file('src/guide.txt')
+
+    assert engine.should_include_file(target_file) is True
+    assert engine.should_include_file(off_target_file) is False
+    return None
+
+
+def test_combined_filters_in_engine() -> None:
+    """Scenario: Combination of filters (include + exclude + size constraints)"""
+    criteria = FilterCriteria(
+        include_patterns=["src/*.py"],
+        exclude_patterns=["*/test_*.py"],
+        min_file_size=50,
+        max_file_size=500,
+        file_extensions={".py"},
+    )
+    engine = FilterEngine(criteria)
+
+    files = [
+        make_file("src/main.py", size=200),
+        make_file("src/test_helper.py", size=200),
+        make_file("src/small.py", size=10),
+        make_file("src/large.py", size=600),
+        make_file("src/docs/readme.md", size=100),
+        make_file("src/utils/helper.py", size=300, file_type="tree"),
+    ]
+
+    result = engine.filter_files(files)
+
+    assert [file.path for file in result.included_files] == ["src/main.py"]
+    assert {file.path for file in result.excluded_files} == {
+        "src/test_helper.py",
+        "src/small.py",
+        "src/large.py",
+        "src/docs/readme.md",
+        "src/utils/helper.py",
+    }
+    assert result.total_files == len(files)
+    assert result.filtered_files == 1
+    return None
+
+
+if __name__ == '__main__':
+    import sys
+    import pytest
+    sys.exit(pytest.main([__file__]))


### PR DESCRIPTION
Here’s a polished PR description you can drop in:

---

# Add comprehensive filter tests for `FilterCriteria` and `FilterEngine`

This pull request addresses **issue #18** by adding a focused test suite that validates path and file filtering behavior across common scenarios.

## ✅ What’s covered

* ✅ Path matching with `include_patterns`
* ✅ Path exclusion with `exclude_patterns`
* ✅ Handling of hidden files (`include_hidden=True/False`)
* ✅ File extension filtering (`file_extensions` and `excluded_extensions`)
* ✅ `target_paths` enforcement (with and without `FilterEngine`)
* ✅ Combination of filters (include + exclude + size constraints + file type)

---

## Test Scenarios

### 1) Path matching with `include_patterns`

**Goal:** Only include files that match the include glob.

* **Setup:** `FilterCriteria(include_patterns=['*.py'])`
* **Checks:**

  * `main.py` → **True** (included)
  * `README.md` → **False** (excluded)

### 2) Path exclusion with `exclude_patterns`

**Goal:** Exclude files that match the exclude glob, allow others.

* **Setup:** `FilterCriteria(exclude_patterns=['*.md'])`
* **Checks:**

  * `script.py` → **True** (not excluded)
  * `docs/README.md` → **False** (excluded)

### 3) Handling of hidden files (`include_hidden`)

**Goal:** Respect hidden-file behavior based on configuration.

* **Setup:** Hidden path: `.github/workflows/ci.yml`
* **Checks:**

  * `FilterCriteria(include_hidden=False)` → `.github/...` → **False** (hidden files excluded)
  * `FilterCriteria(include_hidden=True)` → `.github/...` → **True** (hidden files included)

### 4) File extension filters

**Goal:** Allow only whitelisted extensions and block blacklisted ones.

* **Setup:** `FilterCriteria(file_extensions={'.py'}, excluded_extensions={'.log'})`
* **Checks:**

  * `src/app.py` → **True** (allowed extension)
  * `src/app.txt` → **False** (not in allowed set)
  * `logs/error.log` → **False** (explicitly excluded)

### 5) `target_paths` enforcement

**Goal:** Only include matches that live under specific path prefixes.

* **Setup:** `FilterCriteria(target_paths=['docs/'], include_patterns=['*.md'])`
* **Checks:**

  * `criteria.matches_path('docs/guide.md')` → **True**
  * `criteria.matches_path('src/guide.md')` → **False**
  * With `FilterEngine`:

    * `engine.should_include_file(make_file('docs/guide.txt'))` → **True** (targeted path)
    * `engine.should_include_file(make_file('src/guide.txt'))` → **False** (off-target)

### 6) Combined filters in `FilterEngine`

**Goal:** Validate interaction between include/exclude patterns, size limits, extensions, and file types.

* **Setup:**

  ```py
  FilterCriteria(
      include_patterns=["src/*.py"],
      exclude_patterns=["*/test_*.py"],
      min_file_size=50,
      max_file_size=500,
      file_extensions={".py"},
  )
  ```

  (Note: a file with `type="tree"` is deliberately excluded.)
* **Checks:**

  * **Included:** `src/main.py` (size within bounds, matches include, not excluded, correct extension, correct type)
  * **Excluded:**

    * `src/test_helper.py` (matches exclude)
    * `src/small.py` (size < min)
    * `src/large.py` (size > max)
    * `src/docs/readme.md` (wrong extension + path pattern mismatch)
    * `src/utils/helper.py` with `type="tree"` (non-blob)

---

## How to run

```bash
python test_filter_engine.py
```

*(The `return None` statements are harmless and ignored by pytest; they make intent explicit.)*

---

## Backwards compatibility & risk

* **No breaking changes** to runtime behavior; this PR only adds tests.
* Guards against regressions in future refactors of filtering logic.

---

**Closes #18.**
