### PR TITLE
fix: use Tuple from typing module for Python 3.8 compatibility

### DIFF
--- a/forklet/interfaces/cli.py
+++ b/forklet/interfaces/cli.py
@@ -6,7 +6,7 @@ Command-line interface for Forklet GitHub Repository Downloader.
 import click
 import sys
 from pathlib import Path
-from typing import List, Optional
+from typing import List, Optional, Tuple
 
 from forklet.core import DownloadOrchestrator
 from forklet.services import GitHubAPIService, DownloadService
@@ -47,7 +47,7 @@ class ForkletCLI:
             self.github_service, self.download_service
         )
     
-    def parse_repository_string(self, repo_str: str) -> tuple[str, str]:
+    def parse_repository_string(self, repo_str: str) -> Tuple[str, str]:
         """
         Parse repository string in format owner/repo.
         


### PR DESCRIPTION
- Replace built-in tuple type annotation with Tuple from typing module
- Ensures compatibility with Python 3.8 and earlier versions
- Fixes type annotation in parse_repository_string method return type

The built-in tuple type for type hints was introduced in Python 3.9. Using Tuple from typing module maintains backward compatibility.